### PR TITLE
fix: exposing Frame properties and removing redundant calls to __convert_disposal_mode__  

### DIFF
--- a/ImageScript.d.ts
+++ b/ImageScript.d.ts
@@ -153,6 +153,16 @@ export class Frame extends Image {
 
   constructor(width: number, height: number, duration?: number, xOffset?: number, yOffset?: number, disposalMode?: typeof Frame.DISPOSAL_KEEP | string);
 
+  duration: number;
+
+  xOffset: number;
+
+  yOffset: number;
+
+  get disposalMode(): number;
+
+  set disposalMode(disposalMode: string|number);
+  
   toString(): string;
 
   static from(image: Image, duration?: number, xOffset?: number, yOffset?: number, disposalMode?: typeof Frame.DISPOSAL_KEEP | string): Frame;

--- a/ImageScript.js
+++ b/ImageScript.js
@@ -1269,13 +1269,27 @@ class Frame extends Image {
         if (isNaN(duration) || duration < 0)
             throw new RangeError('Invalid frame duration');
 
-        disposalMode = Frame.__convert_disposal_mode__(disposalMode);
-
         super(width, height);
         this.duration = duration;
         this.xOffset = xOffset;
         this.yOffset = yOffset;
         this.disposalMode = disposalMode;
+    }
+
+    /**
+     * The Frame's disposal mode
+     * @returns {number}
+     */
+    get disposalMode() {
+        return this.__disposalMode__;
+    }
+
+    /**
+     * Sets the frame's disposal mode, converting it to the internal numeric value.
+     * @param {string|number} disposalMode The frame's disposal mode
+     */
+    set disposalMode(disposalMode) {
+        this.__disposalMode__ = Frame.__convert_disposal_mode__(disposalMode);
     }
 
     toString() {
@@ -1294,8 +1308,6 @@ class Frame extends Image {
     static from(image, duration, xOffset, yOffset, disposalMode = Frame.DISPOSAL_KEEP) {
         if (!(image instanceof Image))
             throw new TypeError('Invalid image passed');
-
-        disposalMode = Frame.__convert_disposal_mode__(disposalMode);
 
         const frame = new Frame(image.width, image.height, duration, xOffset, yOffset, disposalMode);
         frame.bitmap.set(image.bitmap);


### PR DESCRIPTION
Hello,

I wanted to access the duration and disposalMode properties in the Frame class, so i added them to ImageScript.d.ts and made a setter that calls Frame.__convert_disposal_mode__(disposalMode).

I also removed the direct calls to __convert_disposal_mode__  in the constructor and from() since the assignment will call the setter.